### PR TITLE
fix: handle syscalls only on exit

### DIFF
--- a/src/rpc_tracer.cc
+++ b/src/rpc_tracer.cc
@@ -255,26 +255,26 @@ void RpcTracer::HandleLeaveClose([[maybe_unused]] pid_t tid, int fd, int rc) {
   addresses_.erase(fd);
 }
 
-void RpcTracer::DispatchSyscallHandler(pid_t tid, uint64_t syscall, bool is_enter, uint64_t arg0,
+void RpcTracer::DispatchSyscallHandler(pid_t tid, uint64_t syscall, uint64_t arg0,
                                        uint64_t arg1, uint64_t arg2, uint64_t rc) {
   // KJ_DBG(syscall, is_enter, arg0, arg1, arg2, rc);
-  if (syscall == SYS_connect && !is_enter) {
+  if (syscall == SYS_connect) {
     HandleLeaveConnect(tid, static_cast<int>(arg0), arg1, arg2, static_cast<int>(rc));
-  } else if (syscall == SYS_read && !is_enter) {
+  } else if (syscall == SYS_read) {
     // for Cap'n Proto C++
     HandleLeaveReadRecvfrom(tid, static_cast<int>(arg0), arg1, arg2, static_cast<int>(rc));
-  } else if (syscall == SYS_writev && !is_enter) {
+  } else if (syscall == SYS_writev) {
     // for Cap'n Proto C++
     HandleLeaveWritev(tid, static_cast<int>(arg0), arg1, arg2, static_cast<int>(rc));
-  } else if (syscall == SYS_recvfrom && !is_enter) {
+  } else if (syscall == SYS_recvfrom) {
     // for Cap'n Proto Rust
     HandleLeaveReadRecvfrom(tid, static_cast<int>(arg0), arg1, arg2, static_cast<int>(rc));
-  } else if (syscall == SYS_write && !is_enter) {
+  } else if (syscall == SYS_write) {
     // for Cap'n Proto Rust
     HandleLeaveWrite(tid, static_cast<int>(arg0), arg1, arg2, static_cast<int>(rc));
-  } else if (syscall == SYS_readv && !is_enter) {
+  } else if (syscall == SYS_readv) {
     HandleLeaveReadv(tid, static_cast<int>(arg0), arg1, arg2, static_cast<int>(rc));
-  } else if (syscall == SYS_close && !is_enter) {
+  } else if (syscall == SYS_close) {
     HandleLeaveClose(tid, static_cast<int>(arg0), static_cast<int>(rc));
   }
 }
@@ -302,6 +302,7 @@ void RpcTracer::Trace() {
       struct __ptrace_syscall_info syscall_info;
       KJ_SYSCALL(ptrace(PTRACE_GET_SYSCALL_INFO, tid, sizeof(syscall_info), &syscall_info));
       bool is_enter = syscall_info.op == PTRACE_SYSCALL_INFO_ENTRY;
+      bool is_exit = syscall_info.op == PTRACE_SYSCALL_INFO_EXIT;
 
 #if defined(__aarch64__)
       struct user_regs_struct regs;
@@ -333,7 +334,9 @@ void RpcTracer::Trace() {
       uint64_t arg2    = regs.rdx;
 #endif
 
-      DispatchSyscallHandler(tid, syscall, is_enter, arg0, arg1, arg2, rc);
+      if (is_exit) {
+        DispatchSyscallHandler(tid, syscall, arg0, arg1, arg2, rc);
+      }
     }
 
     KJ_SYSCALL(ptrace(PTRACE_SYSCALL, tid, nullptr, nullptr));

--- a/src/rpc_tracer.h
+++ b/src/rpc_tracer.h
@@ -40,7 +40,7 @@ class RpcTracer final {
   void HandleLeaveReadRecvfrom(pid_t tid, int fd, uint64_t addr, uint64_t count, int rc);
   void HandleLeaveReadv(pid_t tid, int fd, uint64_t iov_addr, uint64_t iov_count, int rc);
   void HandleLeaveClose(pid_t tid, int fd, int rc);
-  void DispatchSyscallHandler(pid_t tid, uint64_t syscall, bool is_enter, uint64_t arg0,
+  void DispatchSyscallHandler(pid_t tid, uint64_t syscall, uint64_t arg0,
                               uint64_t arg1, uint64_t arg2, uint64_t rc);
 
   // PID to be traced


### PR DESCRIPTION
# Overview
Fix trivial bugs.

## Fix
- Fix condition to catch ptrace event, to capture only exit.

## Test Results

### Unit Test
OK

```bash
$ cmake --build build --target test
Running tests...
Test project /home/hisami/work/capnp-trace/build
    Start 1: capnp_trace_unittest
1/1 Test #1: capnp_trace_unittest .............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.00 sec
```

### Interface Test
OK

(1) Run Server  
```bash
$ ./build/test/capnp_test_interface server /tmp/test_sock
```

(2) Attach from capnp_trace to server
```bash
sudo ./build/src/capnp_trace attach /tmp/test_sock $(pidof capnp_test_interface)
```

(3) Run client
```bash
./build/test/capnp_test_interface client /tmp/test_sock
/home/hisami/work/capnp-trace/test/capnp_test_interface.cc:32: debug: req.send().wait(client.getWaitScope()).getX() = test result
```

(4) We can see the following logs on (2)'s capnp_trace console
```bash
# x86_64
145061.0694 2198705/2198705 <- /tmp/test.sock(7) BOOTSTRAP(0)
145061.0696 2198705/2198705 -> /tmp/test.sock(7) RETURN(0) (null struct schema) (<external capability>)
145061.0697 2198705/2198705 <- /tmp/test.sock(7) CALL(1) test.capnp:TestInterface.foo(i = 1234, j = true)
145061.0698 2198705/2198705 -> /tmp/test.sock(7) RETURN(1) test.capnp:TestInterface.foo$Results (x = "test result")
145061.0699 2198705/2198705 <- /tmp/test.sock(7) FINISH(0)

# aarch64
018186.7538 9999/9999 <- /tmp/test.sock(7) BOOTSTRAP(0)
018186.7554 9999/9999 -> /tmp/test.sock(7) RETURN(0) (null struct schema) (<external capability>)
018186.7558 9999/9999 <- /tmp/test.sock(7) CALL(1) test.capnp:TestInterface.foo(i = 1234, j = true)
018186.7563 9999/9999 -> /tmp/test.sock(7) RETURN(1) test.capnp:TestInterface.foo$Results (x = "test result")
018186.7568 9999/9999 <- /tmp/test.sock(7) FINISH(0)
```