### PR TITLE
fix: add guard for kTypeStrings boundary

### DIFF
--- a/src/capnp_trace.cc
+++ b/src/capnp_trace.cc
@@ -347,6 +347,16 @@ class TraceMain final {
         "PROVIDE",       "ACCEPT",  "JOIN",          "DISEMBARGO",
     };
 
+    if (type >= kj::size(kTypeStrings)) {
+      // The maximum value of capnp::rpc::Message::Which may change across versions of Cap'n Proto.
+      // So, type may exceed the size of kTypeStrings.
+      //
+      // But, This is not a fundamental fix. We can't wait for static reflection in C++26!
+      // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2996r10.html
+      KJ_LOG(WARNING, "Unknown capnp::rpc::Message type.");
+      abort();
+    }
+
     switch (type) {
       case capnp::rpc::Message::UNIMPLEMENTED:
       case capnp::rpc::Message::ABORT:


### PR DESCRIPTION
# Overview
Fix trivial bugs.

## Fix
- Add a boundary check of kTypeStrings, because the index for kTypeStrings may change accross versions of Cap'n Proto in the user's environment.

## Test Results

### Unit Test
OK

```bash
$ cmake --build build --target test
Running tests...
Test project /home/hisami/work/capnp-trace/build
    Start 1: capnp_trace_unittest
1/1 Test #1: capnp_trace_unittest .............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.00 sec
```

### Interface Test
OK

(1) Run Server  
```bash
$ ./build/test/capnp_test_interface server /tmp/test_sock
```

(2) Attach from capnp_trace to server
```bash
sudo ./build/src/capnp_trace attach /tmp/test_sock $(pidof capnp_test_interface)
```

(3) Run client
```bash
./build/test/capnp_test_interface client /tmp/test_sock
/home/hisami/work/capnp-trace/test/capnp_test_interface.cc:32: debug: req.send().wait(client.getWaitScope()).getX() = test result
```

(4) We can see the following logs on (2)'s capnp_trace console
```bash
# x86_64
144798.9450 2195778/2195778 <- /tmp/test.sock(7) BOOTSTRAP(0)
144798.9453 2195778/2195778 -> /tmp/test.sock(7) RETURN(0) (null struct schema) (<external capability>)
144798.9453 2195778/2195778 <- /tmp/test.sock(7) CALL(1) test.capnp:TestInterface.foo(i = 1234, j = true)
144798.9455 2195778/2195778 -> /tmp/test.sock(7) RETURN(1) test.capnp:TestInterface.foo$Results (x = "test result")
144798.9455 2195778/2195778 <- /tmp/test.sock(7) FINISH(0)

# aarch64
017951.3651 9859/9859 <- /tmp/test.sock(7) BOOTSTRAP(0)
017951.3656 9859/9859 -> /tmp/test.sock(7) RETURN(0) (null struct schema) (<external capability>)
017951.3661 9859/9859 <- /tmp/test.sock(7) CALL(1) test.capnp:TestInterface.foo(i = 1234, j = true)
017951.3667 9859/9859 -> /tmp/test.sock(7) RETURN(1) test.capnp:TestInterface.foo$Results (x = "test result")
017951.3670 9859/9859 <- /tmp/test.sock(7) FINISH(0)
```