### PR TITLE
fix: typo

### DIFF
--- a/src/rpc_tracer.cc
+++ b/src/rpc_tracer.cc
@@ -246,7 +246,7 @@ void RpcTracer::HandleLeaveReadv(pid_t tid, int fd, uint64_t iov_addr, uint64_t 
 
 void RpcTracer::HandleLeaveClose([[maybe_unused]] pid_t tid, int fd, int rc) {
   if (rc < 0) {
-    KJ_LOG(INFO, "failed readv");
+    KJ_LOG(INFO, "failed close");
     return;
   }
 


### PR DESCRIPTION
# Overview
Fix trivial bugs.

## Fix
- Fix typo of a log.

## Test Results

### Unit Test
OK

```bash
$ cmake --build build --target test
Running tests...
Test project /home/hisami/work/capnp-trace/build
    Start 1: capnp_trace_unittest
1/1 Test #1: capnp_trace_unittest .............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.00 sec
```

### Interface Test
OK

(1) Run Server  
```bash
$ ./build/test/capnp_test_interface server /tmp/test_sock
```

(2) Attach from capnp_trace to server
```bash
sudo ./build/src/capnp_trace attach /tmp/test_sock $(pidof capnp_test_interface)
```

(3) Run client
```bash
./build/test/capnp_test_interface client /tmp/test_sock
/home/hisami/work/capnp-trace/test/capnp_test_interface.cc:32: debug: req.send().wait(client.getWaitScope()).getX() = test result
```

(4) We can see the following logs on (2)'s capnp_trace console


```bash
# aarch64
012755.2470 8381/8381 <- /tmp/test.sock(7) BOOTSTRAP(0)
012755.2476 8381/8381 -> /tmp/test.sock(7) RETURN(0) (null struct schema) (<external capability>)
012755.2510 8381/8381 <- /tmp/test.sock(7) CALL(1) test.capnp:TestInterface.foo(i = 1234, j = true)
012755.2523 8381/8381 -> /tmp/test.sock(7) RETURN(1) test.capnp:TestInterface.foo$Results (x = "test result")
012755.2526 8381/8381 <- /tmp/test.sock(7) FINISH(0)

# x86_64
140187.3529 2167968/2167968 <- /tmp/test.sock(7) BOOTSTRAP(0)
140187.3532 2167968/2167968 -> /tmp/test.sock(7) RETURN(0) (null struct schema) (<external capability>)
140187.3533 2167968/2167968 <- /tmp/test.sock(7) CALL(1) test.capnp:TestInterface.foo(i = 1234, j = true)
140187.3534 2167968/2167968 -> /tmp/test.sock(7) RETURN(1) test.capnp:TestInterface.foo$Results (x = "test result")
140187.3534 2167968/2167968 <- /tmp/test.sock(7) FINISH(0)
```